### PR TITLE
Feature/gradle namespace proguard updates

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,4 +20,3 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keep class com.riskident.** { *;}

--- a/app/src/androidTest/java/de/deviceident/deviceidentsample/ExampleInstrumentedTest.java
+++ b/app/src/androidTest/java/de/deviceident/deviceidentsample/ExampleInstrumentedTest.java
@@ -1,4 +1,4 @@
-package com.riskident.deviceidentsample;
+package de.deviceident.deviceidentsample;
 
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
@@ -21,6 +21,6 @@ public class ExampleInstrumentedTest {
         // Context of the app under test.
         Context appContext = InstrumentationRegistry.getTargetContext();
 
-        assertEquals("com.riskident.deviceidentsample", appContext.getPackageName());
+        assertEquals("de.deviceident.deviceidentsample", appContext.getPackageName());
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.riskident.deviceidentsample">
+    package="de.deviceident.deviceidentsample">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>

--- a/app/src/main/java/de/deviceident/deviceidentsample/MainActivity.java
+++ b/app/src/main/java/de/deviceident/deviceidentsample/MainActivity.java
@@ -1,4 +1,4 @@
-package com.riskident.deviceidentsample;
+package de.deviceident.deviceidentsample;
 
 import android.Manifest;
 import android.app.Activity;

--- a/app/src/main/java/de/deviceident/deviceidentsample/MainApplication.java
+++ b/app/src/main/java/de/deviceident/deviceidentsample/MainApplication.java
@@ -1,4 +1,4 @@
-package com.riskident.deviceidentsample;
+package de.deviceident.deviceidentsample;
 
 import android.app.Application;
 import com.riskident.device.ClientSecurityModule;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,7 +4,7 @@
     android:id="@+id/mainactivity_layout_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.riskident.deviceidentsample.MainActivity">
+    tools:context="de.deviceident.deviceidentsample.MainActivity">
 
     <TextView
         android:id="@+id/mainactivity_textview_header"

--- a/app/src/test/java/de/deviceident/deviceidentsample/ExampleUnitTest.java
+++ b/app/src/test/java/de/deviceident/deviceidentsample/ExampleUnitTest.java
@@ -1,4 +1,4 @@
-package com.riskident.deviceidentsample;
+package de.deviceident.deviceidentsample;
 
 import org.junit.Test;
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.6.3'
 
 
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 24 08:54:11 CEST 2019
+#Fri Aug 07 12:41:55 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip


### PR DESCRIPTION
- upgrade gradle to recent version
- move sample app to different namespace than clientsecuritymodule (this is to mimic customer apps)
- enable proguard obfuscation (again, customers will have this on for release)